### PR TITLE
Implement parameter verification

### DIFF
--- a/mockingbird/core/src/main/kotlin/com/mockingbird/core/Verifiable.kt
+++ b/mockingbird/core/src/main/kotlin/com/mockingbird/core/Verifiable.kt
@@ -4,6 +4,8 @@ interface Verifiable {
 
     val invocations: MutableList<Pair<String, List<Any>>>
 
+    var nextInvocationParamVerifier: ((List<Any>) -> Boolean)?
+
     var verifying: Boolean
 
     var expected: Int
@@ -24,6 +26,20 @@ fun verify(vararg any: Any, block: () -> Unit) {
     verifiable.forEach {
         it.verifying = false
     }
+}
+
+fun <T : Any> T.verifyParams(verifier: (List<Any>) -> Boolean, invocation: T.() -> Unit) {
+    check(this is Verifiable) { "You can only verify interfaces that have been annotated with Verify" }
+    check(this.verifying) { "You can only call verifyParams inside a verify block" }
+    this.nextInvocationParamVerifier = verifier
+    this.invocation()
+}
+
+fun <T : Any> T.verifyIgnoreParams(invocation: T.() -> Unit) {
+    check(this is Verifiable) { "You can only verify interfaces that have been annotated with Verify" }
+    check(this.verifying) { "You can only call verifyIgnoreParams inside a verify block" }
+    this.nextInvocationParamVerifier = { true }
+    this.invocation()
 }
 
 fun Any.verifyNoInvocations() {

--- a/sample/src/main/kotlin/com/mockingbird/sample/ClassToTest.kt
+++ b/sample/src/main/kotlin/com/mockingbird/sample/ClassToTest.kt
@@ -29,4 +29,8 @@ class ClassToTest(
         // Do nothing
     }
 
+    fun act5() {
+        interfaceToVerify1.performAction3(Exception("test"))
+    }
+
 }

--- a/sample/src/main/kotlin/com/mockingbird/sample/InterfaceToVerify1.kt
+++ b/sample/src/main/kotlin/com/mockingbird/sample/InterfaceToVerify1.kt
@@ -6,4 +6,6 @@ interface InterfaceToVerify1 {
 
     fun performAction2(one: String, two: Long)
 
+    fun performAction3(exception: Exception)
+
 }

--- a/sample/src/test/kotlin/com/mockingbird/sample/ClassToTestTest.kt
+++ b/sample/src/test/kotlin/com/mockingbird/sample/ClassToTestTest.kt
@@ -4,7 +4,9 @@ import com.mockingbird.core.Verify
 import com.mockingbird.core.fake
 import com.mockingbird.core.times
 import com.mockingbird.core.verify
+import com.mockingbird.core.verifyIgnoreParams
 import com.mockingbird.core.verifyNoInvocations
+import com.mockingbird.core.verifyParams
 import org.junit.Test
 
 class ClassToTestTest {
@@ -137,6 +139,56 @@ class ClassToTestTest {
 
         verify(interfaceToVerify1) {
             interfaceToVerify1.verifyNoInvocations()
+        }
+    }
+
+    @Test(expected = IllegalStateException::class)
+    fun `verification of inequitable type expected failure`() {
+        val classToTest = ClassToTest(interfaceToVerify1, interfaceToVerify2)
+
+        classToTest.act5()
+
+        verify(interfaceToVerify1) {
+            interfaceToVerify1.performAction3(Exception("test"))
+        }
+    }
+
+    @Test
+    fun `verification of inequitable type with verifyIgnoreParameter`() {
+        val classToTest = ClassToTest(interfaceToVerify1, interfaceToVerify2)
+
+        classToTest.act5()
+
+        verify(interfaceToVerify1) {
+            interfaceToVerify1.verifyIgnoreParams { performAction3(Exception("test")) }
+        }
+    }
+
+    @Test
+    fun `verification of inequitable type with verifyParams`() {
+        val classToTest = ClassToTest(interfaceToVerify1, interfaceToVerify2)
+
+        classToTest.act5()
+
+        verify(interfaceToVerify1) {
+            interfaceToVerify1.verifyParams(
+                verifier = { (it[0] as? Exception)?.message == "test" },
+                invocation = { performAction3(Exception("test")) }
+            )
+        }
+    }
+
+    @Test(expected = IllegalStateException::class)
+    fun `verification of inequitable type with verifyParams expected failure`() {
+        val classToTest = ClassToTest(interfaceToVerify1, interfaceToVerify2)
+
+        classToTest.act5()
+
+        verify(interfaceToVerify1) {
+            interfaceToVerify1.verifyParams(
+                verifier = { (it[0] as? Exception)?.message == "test1" },
+                invocation = { performAction3(Exception("test")) }
+            )
         }
     }
 }


### PR DESCRIPTION
Implements
- `verifyParams(verifier, invocation)`
- `verifyIgnoreParams(invocation)`

Usage is as follows for `verifyParams`
```kotlin
verify(interface1) {
    interface1.verifyParams(
        verifier = { it[0] == "true" },
        invocation = { callFunction("true") }
    )
}
``` 
Usage is as follows for `verifyIgnoreParams`
```kotlin
verify(interface1) {
    interface1.verifyIgnoreParams(invocation = { callFunction("true") }
}
```

Closes https://github.com/anthonycr/Mockingbird/issues/3