### PR TITLE
Switch to Zac Sweers Kotlin Compile testing fork.

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -9,7 +9,7 @@ junit = { group = "junit", name = "junit", version.ref = "junit" }
 ksp-api = { group = "com.google.devtools.ksp", name = "symbol-processing-api", version.ref = "ksp" }
 kotlinpoet = { group = "com.squareup", name = "kotlinpoet", version.ref = "kotlinpoet" }
 kotlinpoet-ksp = { group = "com.squareup", name = "kotlinpoet-ksp", version.ref = "kotlinpoet" }
-compiletesting = { group = "com.github.tschuchortdev", name = "kotlin-compile-testing-ksp", version = "1.5.0" }
+compiletesting = { group = "dev.zacsweers.kctfork", name = "ksp", version = "0.4.1" }
 
 [plugins]
 ksp-plugin = { id = "com.google.devtools.ksp", version.ref = "ksp" }

--- a/mockingbird/processor/src/test/kotlin/com/anthonycr/mockingbird/processor/MockingbirdSymbolProcessorTest.kt
+++ b/mockingbird/processor/src/test/kotlin/com/anthonycr/mockingbird/processor/MockingbirdSymbolProcessorTest.kt
@@ -3,11 +3,13 @@ package com.anthonycr.mockingbird.processor
 import com.tschuchort.compiletesting.KotlinCompilation
 import com.tschuchort.compiletesting.SourceFile
 import com.tschuchort.compiletesting.symbolProcessorProviders
+import org.jetbrains.kotlin.compiler.plugin.ExperimentalCompilerApi
 import org.junit.Assert
 import org.junit.Rule
 import org.junit.Test
 import org.junit.rules.TemporaryFolder
 
+@OptIn(ExperimentalCompilerApi::class)
 class MockingbirdSymbolProcessorTest {
 
     @Rule


### PR DESCRIPTION
The original Kotlin compile testing library isn't being actively maintained so this PR just migrates to a fork that is being maintained and updated to each of the latest versions of Kotlin. 

Forked repo: https://github.com/ZacSweers/kotlin-compile-testing

Relevant Issue comment: https://github.com/tschuchortdev/kotlin-compile-testing/issues/390#issuecomment-1793850804