### PR TITLE
Use kspTest instead of just ksp

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Include the following dependencies in your `build.gradle.kts` file.
 
 ```kotlin
 testImplementation(project(":mockingbird:core")
-ksp(project(":mockingbird:processor"))
+kspTest(project(":mockingbird:processor"))
 ```
 
 Make sure you have the KSP Gradle plugin enabled as well.

--- a/sample/build.gradle.kts
+++ b/sample/build.gradle.kts
@@ -6,5 +6,5 @@ plugins {
 dependencies {
     testImplementation(libs.junit)
     testImplementation(project(":mockingbird:core"))
-    ksp(project(":mockingbird:processor"))
+    kspTest(project(":mockingbird:processor"))
 }


### PR DESCRIPTION
Mockingbird should be added using `kspTest` instead of `ksp` since it only needs to run on test sources.