### PR TITLE
Improving code generation and fixing Pair collision

### DIFF
--- a/mockingbird/core/src/main/kotlin/com/anthonycr/mockingbird/core/Verifiable.kt
+++ b/mockingbird/core/src/main/kotlin/com/anthonycr/mockingbird/core/Verifiable.kt
@@ -4,7 +4,12 @@ package com.anthonycr.mockingbird.core
 
 interface Verifiable {
 
-    val _mockingbird_invocations: MutableList<Pair<String, List<Any?>>>
+    data class Invocation(
+        val functionName: String,
+        val parameters: List<Any?>
+    )
+
+    val _mockingbird_invocations: MutableList<Invocation>
 
     var _mockingbird_paramMatcher: List<(Any?, Any?) -> Boolean>
 
@@ -35,7 +40,7 @@ fun Any.verifyNoInvocations() {
     check(!this._mockingbird_verifying) { "Do not call verifyNoInvocations from within a verify block" }
 
     this._mockingbird_verifying = true
-    check(this._mockingbird_invocations.isEmpty()) { "Expected no invocations, but found ${this._mockingbird_invocations.size}" }
+    check(this._mockingbird_invocations.isEmpty()) { "Expected no invocations, but found ${this._mockingbird_invocations.size} unverified" }
     this._mockingbird_verifying = false
 }
 

--- a/mockingbird/processor/src/main/kotlin/com/anthonycr/mockingbird/processor/MockingbirdSymbolProcessor.kt
+++ b/mockingbird/processor/src/main/kotlin/com/anthonycr/mockingbird/processor/MockingbirdSymbolProcessor.kt
@@ -178,21 +178,22 @@ class MockingbirdSymbolProcessor(
             val functionName = function.qualifiedName!!.asString()
 
             funSpec.beginControlFlow("if (_mockingbird_verifying)")
-                .addStatement("val expectedInvocations = _mockingbird_invocations.take(_mockingbird_expected)")
-                .addStatement("_mockingbird_invocations.removeAll(expectedInvocations)")
-                .beginControlFlow("check(expectedInvocations.size == _mockingbird_expected)")
+                .addStatement("val invocations = _mockingbird_invocations.take(_mockingbird_expected)")
+                .addStatement("_mockingbird_invocations.removeAll(invocations)")
+                .beginControlFlow("check(invocations.size == _mockingbird_expected)")
                 .addStatement(
-                    "\"Expected \$_mockingbird_expected invocations, but got \${expectedInvocations.size} instead.\"".noWrap(),
+                    "\"Expected \$_mockingbird_expected invocations, but got \${invocations.size} instead\"".noWrap(),
                 )
                 .endControlFlow()
-                .beginControlFlow("expectedInvocations.forEach")
+                .beginControlFlow("invocations.forEach")
+                .beginControlFlow("check(it.functionName == %S)", functionName)
+                .addStatement(
+                    "\"Expected function call %1L, \${it.functionName} was called instead\"".noWrap(),
+                    functionName,
+                )
+                .endControlFlow()
                 .apply {
-                    beginControlFlow("check(it.functionName == %S)", functionName)
-                    addStatement(
-                        "\"Expected function call %1L, \${it.functionName} was called instead\"".noWrap(),
-                        functionName,
-                    )
-                    endControlFlow()
+                    if (function.parameters.isEmpty()) return@apply
                     beginControlFlow("val allParamVerifier = _mockingbird_paramMatcher.firstOrNull()?.takeIf { _ ->")
                     addStatement("_mockingbird_paramMatcher.size != it.parameters.size")
                     endControlFlow()


### PR DESCRIPTION
Eliminates an issue where the `kotlin.Pair` type could cause a collision with `android.util.Pair` due to the way the code was being generated. I took the opportunity to improve the readability of the generated code by creating an `Invocation` class instead of using the `Pair` type. I also eliminated the generation of parameter verification code that wasn't needed when a function had no parameters.