### PR TITLE
Generate functions with non unit return types, but don't allow calling them

### DIFF
--- a/sample/src/main/kotlin/com/anthonycr/mockingbird/sample/ClassToTest.kt
+++ b/sample/src/main/kotlin/com/anthonycr/mockingbird/sample/ClassToTest.kt
@@ -37,4 +37,8 @@ class ClassToTest(
         interfaceToVerify1.performAction4("one", 2, Exception("test"))
     }
 
+    fun act7() {
+        interfaceToVerify2.cantPerformAction3()
+    }
+
 }

--- a/sample/src/main/kotlin/com/anthonycr/mockingbird/sample/InterfaceToVerify2.kt
+++ b/sample/src/main/kotlin/com/anthonycr/mockingbird/sample/InterfaceToVerify2.kt
@@ -5,4 +5,6 @@ interface InterfaceToVerify2 {
     fun performAction1(one: Long, two: String, three: String)
 
     fun performAction2()
+
+    fun cantPerformAction3(): Boolean
 }

--- a/sample/src/test/kotlin/com/anthonycr/mockingbird/sample/ClassToTestTest.kt
+++ b/sample/src/test/kotlin/com/anthonycr/mockingbird/sample/ClassToTestTest.kt
@@ -210,4 +210,11 @@ class ClassToTestTest {
             )
         }
     }
+
+    @Test(expected = IllegalStateException::class)
+    fun `verification of non Unit returns is not allowed`() {
+        val classToTest = ClassToTest(interfaceToVerify1, interfaceToVerify2)
+
+        classToTest.act7()
+    }
 }


### PR DESCRIPTION
I don't want this to be used as a mocking library, so I don't want to return default values for non-unit functions. However, it is technically valid usage to want to verify that a function with a unit return was called, when there are other functions with non unit returns on the interface definition. Just ensuring that the functions throw an exception so that tests can't become dependent on default returns should be good enough,