### PR TITLE
Implement support for verifying suspending functions

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -11,6 +11,7 @@ kotlinpoet = { group = "com.squareup", name = "kotlinpoet", version.ref = "kotli
 kotlinpoet-ksp = { group = "com.squareup", name = "kotlinpoet-ksp", version.ref = "kotlinpoet" }
 compiletesting = { group = "dev.zacsweers.kctfork", name = "ksp", version = "0.4.1" }
 mockk = { group = "io.mockk", name = "mockk", version = "1.13.10" }
+coroutines-test = { group = "org.jetbrains.kotlinx", name = "kotlinx-coroutines-test", version = "1.8.0" }
 
 [plugins]
 ksp-plugin = { id = "com.google.devtools.ksp", version.ref = "ksp" }

--- a/mockingbird/core/src/main/kotlin/com/anthonycr/mockingbird/core/Verifiable.kt
+++ b/mockingbird/core/src/main/kotlin/com/anthonycr/mockingbird/core/Verifiable.kt
@@ -18,6 +18,23 @@ interface Verifiable {
     var _mockingbird_expected: Int
 }
 
+suspend fun verifySuspend(vararg any: Any, block: suspend () -> Unit) {
+    val verifiable: List<Verifiable> = any.map {
+        check(it is Verifiable) { MUST_BE_VERIFIABLE }
+        it
+    }
+
+    verifiable.forEach {
+        check(!it._mockingbird_verifying) { "Do not call verify within another verify block" }
+        it._mockingbird_verifying = true
+        it._mockingbird_expected = 1
+    }
+    block()
+    verifiable.forEach {
+        it._mockingbird_verifying = false
+    }
+}
+
 fun verify(vararg any: Any, block: () -> Unit) {
     val verifiable: List<Verifiable> = any.map {
         check(it is Verifiable) { MUST_BE_VERIFIABLE }

--- a/mockingbird/processor/src/main/kotlin/com/anthonycr/mockingbird/processor/MockingbirdSymbolProcessor.kt
+++ b/mockingbird/processor/src/main/kotlin/com/anthonycr/mockingbird/processor/MockingbirdSymbolProcessor.kt
@@ -1,5 +1,7 @@
 package com.anthonycr.mockingbird.processor
 
+import com.anthonycr.mockingbird.core.Verifiable
+import com.anthonycr.mockingbird.core.Verify
 import com.google.devtools.ksp.processing.CodeGenerator
 import com.google.devtools.ksp.processing.KSPLogger
 import com.google.devtools.ksp.processing.Resolver
@@ -10,19 +12,15 @@ import com.google.devtools.ksp.symbol.KSClassDeclaration
 import com.google.devtools.ksp.symbol.KSFunctionDeclaration
 import com.google.devtools.ksp.symbol.KSNode
 import com.google.devtools.ksp.symbol.KSPropertyDeclaration
-import com.anthonycr.mockingbird.core.Verifiable
-import com.anthonycr.mockingbird.core.Verify
+import com.google.devtools.ksp.symbol.Modifier
 import com.squareup.kotlinpoet.ClassName
-import com.squareup.kotlinpoet.ExperimentalKotlinPoetApi
 import com.squareup.kotlinpoet.FileSpec
 import com.squareup.kotlinpoet.FunSpec
 import com.squareup.kotlinpoet.KModifier
 import com.squareup.kotlinpoet.LambdaTypeName
 import com.squareup.kotlinpoet.MemberName
-import com.squareup.kotlinpoet.ParameterSpec
 import com.squareup.kotlinpoet.ParameterizedTypeName.Companion.parameterizedBy
 import com.squareup.kotlinpoet.PropertySpec
-import com.squareup.kotlinpoet.TypeName
 import com.squareup.kotlinpoet.TypeSpec
 import com.squareup.kotlinpoet.TypeVariableName
 import com.squareup.kotlinpoet.asClassName
@@ -172,6 +170,11 @@ class MockingbirdSymbolProcessor(
             val returnType = function.returnType?.toTypeName() ?: unitTypeName
             val funSpec = FunSpec.builder(function.simpleName.asString())
                 .addModifiers(KModifier.OVERRIDE)
+                .apply {
+                    if (function.modifiers.contains(Modifier.SUSPEND)) {
+                        addModifiers(KModifier.SUSPEND)
+                    }
+                }
                 .returns(returnType)
 
             for (param in function.parameters) {

--- a/sample/build.gradle.kts
+++ b/sample/build.gradle.kts
@@ -5,6 +5,7 @@ plugins {
 
 dependencies {
     testImplementation(libs.junit)
+    testImplementation(libs.coroutines.test)
     testImplementation(project(":mockingbird:core"))
     kspTest(project(":mockingbird:processor"))
 }

--- a/sample/src/main/kotlin/com/anthonycr/mockingbird/sample/ClassToTest.kt
+++ b/sample/src/main/kotlin/com/anthonycr/mockingbird/sample/ClassToTest.kt
@@ -41,4 +41,12 @@ class ClassToTest(
         interfaceToVerify2.cantPerformAction3()
     }
 
+    suspend fun act8() {
+        interfaceToVerify2.performAction4("one")
+    }
+
+    suspend fun act9() {
+        interfaceToVerify2.performAction5()
+    }
+
 }

--- a/sample/src/main/kotlin/com/anthonycr/mockingbird/sample/InterfaceToVerify2.kt
+++ b/sample/src/main/kotlin/com/anthonycr/mockingbird/sample/InterfaceToVerify2.kt
@@ -7,4 +7,8 @@ interface InterfaceToVerify2 {
     fun performAction2()
 
     fun cantPerformAction3(): Boolean
+
+    suspend fun performAction4(string: String)
+
+    suspend fun performAction5(): Boolean
 }

--- a/sample/src/test/kotlin/com/anthonycr/mockingbird/sample/ClassToTestTest.kt
+++ b/sample/src/test/kotlin/com/anthonycr/mockingbird/sample/ClassToTestTest.kt
@@ -10,6 +10,8 @@ import com.anthonycr.mockingbird.core.verify
 import com.anthonycr.mockingbird.core.verifyIgnoreParams
 import com.anthonycr.mockingbird.core.verifyNoInvocations
 import com.anthonycr.mockingbird.core.verifyParams
+import com.anthonycr.mockingbird.core.verifySuspend
+import kotlinx.coroutines.test.runTest
 import org.junit.Test
 
 class ClassToTestTest {
@@ -216,5 +218,27 @@ class ClassToTestTest {
         val classToTest = ClassToTest(interfaceToVerify1, interfaceToVerify2)
 
         classToTest.act7()
+    }
+
+    @Test
+    fun `verification of suspending function works as expected`() = runTest {
+        val classToTest = ClassToTest(interfaceToVerify1, interfaceToVerify2)
+
+        classToTest.act8()
+
+        verifySuspend(interfaceToVerify2) {
+            interfaceToVerify2.performAction4("one")
+        }
+    }
+
+    @Test(expected = IllegalStateException::class)
+    fun `verification of non Unit returns suspending function is not allowed`() = runTest {
+        val classToTest = ClassToTest(interfaceToVerify1, interfaceToVerify2)
+
+        classToTest.act9()
+
+        verifySuspend(interfaceToVerify2) {
+            interfaceToVerify2.performAction5()
+        }
     }
 }


### PR DESCRIPTION
Introduced a `verifySuspending` verification function to verify suspending functions. Intended use is with coroutines test and the `runTest` extension. Non-Unit returning suspending functions are not allowed similar to how non-Unit normal functions are not allowed to be verified.

Closes #22 

