### PR TITLE
Target JVM 17

### DIFF
--- a/.github/workflows/action.yml
+++ b/.github/workflows/action.yml
@@ -13,6 +13,11 @@ jobs:
     steps:
       - name: Checkout sources
         uses: actions/checkout@v4
+      - name: Setup Java
+        uses: actions/setup-java@v4
+        with:
+          distribution: 'temurin'
+          java-version: 17
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v3
       - name: Build

--- a/benchmark-mockingbird/build.gradle.kts
+++ b/benchmark-mockingbird/build.gradle.kts
@@ -3,6 +3,10 @@ plugins {
     alias(libs.plugins.ksp.plugin)
 }
 
+kotlin {
+    jvmToolchain(libs.versions.jvm.get().toInt())
+}
+
 dependencies {
     testImplementation(libs.junit)
     testImplementation(project(":mockingbird:core"))

--- a/benchmark-mockk/build.gradle.kts
+++ b/benchmark-mockk/build.gradle.kts
@@ -3,6 +3,10 @@ plugins {
     alias(libs.plugins.ksp.plugin)
 }
 
+kotlin {
+    jvmToolchain(libs.versions.jvm.get().toInt())
+}
+
 dependencies {
     testImplementation(libs.junit)
     testImplementation(libs.mockk)

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -3,6 +3,7 @@ junit = "4.13.2"
 jetbrainsKotlinJvm = "1.9.23"
 kotlinpoet = "1.16.0"
 ksp = "1.9.23-1.0.20"
+jvm = "17"
 
 [libraries]
 junit = { group = "junit", name = "junit", version.ref = "junit" }

--- a/mockingbird/core/build.gradle.kts
+++ b/mockingbird/core/build.gradle.kts
@@ -5,6 +5,10 @@ plugins {
     alias(libs.plugins.mavenPublish)
 }
 
+kotlin {
+    jvmToolchain(libs.versions.jvm.get().toInt())
+}
+
 mavenPublishing {
     signAllPublications()
     publishToMavenCentral(SonatypeHost.CENTRAL_PORTAL, automaticRelease = true)

--- a/mockingbird/processor/build.gradle.kts
+++ b/mockingbird/processor/build.gradle.kts
@@ -5,6 +5,10 @@ plugins {
     alias(libs.plugins.mavenPublish)
 }
 
+kotlin {
+    jvmToolchain(libs.versions.jvm.get().toInt())
+}
+
 dependencies {
     implementation(project(":mockingbird:core"))
     implementation(libs.ksp.api)

--- a/sample/build.gradle.kts
+++ b/sample/build.gradle.kts
@@ -3,6 +3,10 @@ plugins {
     alias(libs.plugins.ksp.plugin)
 }
 
+kotlin {
+    jvmToolchain(libs.versions.jvm.get().toInt())
+}
+
 dependencies {
     testImplementation(libs.junit)
     testImplementation(libs.coroutines.test)

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -19,6 +19,10 @@ dependencyResolutionManagement {
     }
 }
 
+plugins {
+    id("org.gradle.toolchains.foojay-resolver-convention") version "0.8.0"
+}
+
 rootProject.name = "Mockingbird"
 include(":mockingbird:core")
 include(":mockingbird:processor")


### PR DESCRIPTION
Explicitly set the toolchain used.

Necessary now that it's publishing an inline function.