### PR TITLE
Support verifying. parameters of suspending functions

### DIFF
--- a/mockingbird/core/src/main/kotlin/com/anthonycr/mockingbird/core/Parameter.kt
+++ b/mockingbird/core/src/main/kotlin/com/anthonycr/mockingbird/core/Parameter.kt
@@ -43,8 +43,32 @@ fun <T, P0> T.verifyParams(
     func(p0.expected)
 }
 
+suspend fun <T, P0> T.verifyParams(
+    func: suspend T.(P0) -> Unit,
+    p0: Parameter<P0>
+) {
+    check(this is Verifiable) { MUST_BE_VERIFIABLE }
+    check(this._mockingbird_verifying) { MUST_BE_VERIFYING }
+    this._mockingbird_paramMatcher = listOf { e, a -> p0.matcher(e as P0, a as P0) }
+    func(p0.expected)
+}
+
 fun <T, P0, P1> T.verifyParams(
     func: T.(P0, P1) -> Unit,
+    p0: Parameter<P0>,
+    p1: Parameter<P1>
+) {
+    check(this is Verifiable) { MUST_BE_VERIFIABLE }
+    check(this._mockingbird_verifying) { MUST_BE_VERIFYING }
+    this._mockingbird_paramMatcher = listOf(
+        { e, a -> p0.matcher(e as P0, a as P0) },
+        { e, a -> p1.matcher(e as P1, a as P1) }
+    )
+    func(p0.expected, p1.expected)
+}
+
+suspend fun <T, P0, P1> T.verifyParams(
+    func: suspend T.(P0, P1) -> Unit,
     p0: Parameter<P0>,
     p1: Parameter<P1>
 ) {
@@ -73,8 +97,42 @@ fun <T, P0, P1, P2> T.verifyParams(
     func(p0.expected, p1.expected, p2.expected)
 }
 
+suspend fun <T, P0, P1, P2> T.verifyParams(
+    func: suspend T.(P0, P1, P2) -> Unit,
+    p0: Parameter<P0>,
+    p1: Parameter<P1>,
+    p2: Parameter<P2>
+) {
+    check(this is Verifiable) { MUST_BE_VERIFIABLE }
+    check(this._mockingbird_verifying) { MUST_BE_VERIFYING }
+    this._mockingbird_paramMatcher = listOf(
+        { e, a -> p0.matcher(e as P0, a as P0) },
+        { e, a -> p1.matcher(e as P1, a as P1) },
+        { e, a -> p2.matcher(e as P2, a as P2) }
+    )
+    func(p0.expected, p1.expected, p2.expected)
+}
+
 fun <T, P0, P1, P2, P3> T.verifyParams(
     func: T.(P0, P1, P2, P3) -> Unit,
+    p0: Parameter<P0>,
+    p1: Parameter<P1>,
+    p2: Parameter<P2>,
+    p3: Parameter<P3>
+) {
+    check(this is Verifiable) { MUST_BE_VERIFIABLE }
+    check(this._mockingbird_verifying) { MUST_BE_VERIFYING }
+    this._mockingbird_paramMatcher = listOf(
+        { e, a -> p0.matcher(e as P0, a as P0) },
+        { e, a -> p1.matcher(e as P1, a as P1) },
+        { e, a -> p2.matcher(e as P2, a as P2) },
+        { e, a -> p3.matcher(e as P3, a as P3) }
+    )
+    func(p0.expected, p1.expected, p2.expected, p3.expected)
+}
+
+suspend fun <T, P0, P1, P2, P3> T.verifyParams(
+    func: suspend T.(P0, P1, P2, P3) -> Unit,
     p0: Parameter<P0>,
     p1: Parameter<P1>,
     p2: Parameter<P2>,
@@ -111,7 +169,27 @@ fun <T, P0, P1, P2, P3, P4> T.verifyParams(
     func(p0.expected, p1.expected, p2.expected, p3.expected, p4.expected)
 }
 
-fun <T : Any> T.verifyIgnoreParams(invocation: T.() -> Unit) {
+suspend fun <T, P0, P1, P2, P3, P4> T.verifyParams(
+    func: suspend T.(P0, P1, P2, P3, P4) -> Unit,
+    p0: Parameter<P0>,
+    p1: Parameter<P1>,
+    p2: Parameter<P2>,
+    p3: Parameter<P3>,
+    p4: Parameter<P4>
+) {
+    check(this is Verifiable) { MUST_BE_VERIFIABLE }
+    check(this._mockingbird_verifying) { MUST_BE_VERIFYING }
+    this._mockingbird_paramMatcher = listOf(
+        { e, a -> p0.matcher(e as P0, a as P0) },
+        { e, a -> p1.matcher(e as P1, a as P1) },
+        { e, a -> p2.matcher(e as P2, a as P2) },
+        { e, a -> p3.matcher(e as P3, a as P3) },
+        { e, a -> p4.matcher(e as P4, a as P4) }
+    )
+    func(p0.expected, p1.expected, p2.expected, p3.expected, p4.expected)
+}
+
+inline fun <T : Any> T.verifyIgnoreParams(invocation: T.() -> Unit) {
     check(this is Verifiable) { MUST_BE_VERIFIABLE }
     check(this._mockingbird_verifying) { "You can only call verifyIgnoreParams inside a verify block" }
     this._mockingbird_paramMatcher = listOf { _, _ -> true }

--- a/sample/src/test/kotlin/com/anthonycr/mockingbird/sample/ClassToTestTest.kt
+++ b/sample/src/test/kotlin/com/anthonycr/mockingbird/sample/ClassToTestTest.kt
@@ -230,6 +230,20 @@ class ClassToTestTest {
         }
     }
 
+    @Test
+    fun `verification of suspending functions parameters works as expected`() = runTest {
+        val classToTest = ClassToTest(interfaceToVerify1, interfaceToVerify2)
+
+        classToTest.act8()
+
+        verify(interfaceToVerify2) {
+            interfaceToVerify2.verifyParams(
+                func = InterfaceToVerify2::performAction4,
+                p0 = eq("one")
+            )
+        }
+    }
+
     @Test(expected = IllegalStateException::class)
     fun `verification of non Unit returns suspending function is not allowed`() = runTest {
         val classToTest = ClassToTest(interfaceToVerify1, interfaceToVerify2)


### PR DESCRIPTION
Support verifying. parameters of suspending functions by duplicating `verifyParams` functions.