### PR TITLE
Documentation and removal of times function

### DIFF
--- a/mockingbird/core/src/main/kotlin/com/anthonycr/mockingbird/core/Parameter.kt
+++ b/mockingbird/core/src/main/kotlin/com/anthonycr/mockingbird/core/Parameter.kt
@@ -4,18 +4,26 @@ package com.anthonycr.mockingbird.core
 
 private const val MUST_BE_VERIFYING = "You can only call verifyParams inside a verify block"
 
+/**
+ * A parameter that has an expected value that will be matched to the actual value.
+ *
+ * @param expected The expected value that will be matched using the [matcher].
+ * @param matcher Used to determine whether the expected and actual parameters match each other.
+ * Must return `true` if the parameters match, `false` otherwise.
+ */
 data class Parameter<T>(
     val expected: T,
     val matcher: (expected: T, actual: T) -> Boolean
 )
 
 /**
- * Assert that the parameter is equal to [expected] using `==`.
+ * Assert that the actual parameter is equal to [expected] using `==`.
  */
 fun <T> eq(expected: T): Parameter<T> = Parameter(expected) { e, a -> e == a }
 
 /**
- * Assert that the parameter is the same as the [expected] using the criteria provided by the [matcher].
+ * Assert that the actual parameter is the same as the [expected] using the criteria provided by the
+ * [matcher].
  *
  * @param expected The expected parameter that is evaluated against the actual parameter using the
  * [matcher].
@@ -33,6 +41,12 @@ fun <T> sameAs(
  */
 fun <T> any(anything: T): Parameter<T> = Parameter(anything) { _, _ -> true }
 
+/**
+ * Verify that the parameters ([p0]) match for the function call invoked by [func].
+ *
+ * @param func The function to invoke.
+ * @param p0 The first parameter.
+ */
 fun <T, P0> T.verifyParams(
     func: T.(P0) -> Unit,
     p0: Parameter<P0>
@@ -43,6 +57,12 @@ fun <T, P0> T.verifyParams(
     func(p0.expected)
 }
 
+/**
+ * Verify that the parameters ([p0]) match for the suspending function call invoked by [func].
+ *
+ *  @param func The suspending function to invoke.
+ *  @param p0 The first parameter.
+ */
 suspend fun <T, P0> T.verifyParams(
     func: suspend T.(P0) -> Unit,
     p0: Parameter<P0>
@@ -53,6 +73,13 @@ suspend fun <T, P0> T.verifyParams(
     func(p0.expected)
 }
 
+/**
+ * Verify that the parameters ([p0], [p1]) match for the function call invoked by [func].
+ *
+ * @param func The function to invoke.
+ * @param p0 The first parameter.
+ * @param p1 The second parameter.
+ */
 fun <T, P0, P1> T.verifyParams(
     func: T.(P0, P1) -> Unit,
     p0: Parameter<P0>,
@@ -67,6 +94,13 @@ fun <T, P0, P1> T.verifyParams(
     func(p0.expected, p1.expected)
 }
 
+/**
+ * Verify that the parameters ([p0], [p1]) match for the suspending function call invoked by [func].
+ *
+ *  @param func The suspending function to invoke.
+ *  @param p0 The first parameter.
+ *  @param p1 The second parameter.
+ */
 suspend fun <T, P0, P1> T.verifyParams(
     func: suspend T.(P0, P1) -> Unit,
     p0: Parameter<P0>,
@@ -81,6 +115,14 @@ suspend fun <T, P0, P1> T.verifyParams(
     func(p0.expected, p1.expected)
 }
 
+/**
+ * Verify that the parameters ([p0], [p1], [p2]) match for the function call invoked by [func].
+ *
+ * @param func The function to invoke.
+ * @param p0 The first parameter.
+ * @param p1 The second parameter.
+ * @param p2 The third parameter.
+ */
 fun <T, P0, P1, P2> T.verifyParams(
     func: T.(P0, P1, P2) -> Unit,
     p0: Parameter<P0>,
@@ -97,6 +139,15 @@ fun <T, P0, P1, P2> T.verifyParams(
     func(p0.expected, p1.expected, p2.expected)
 }
 
+/**
+ * Verify that the parameters ([p0], [p1], [p2]) match for the suspending function call invoked by
+ * [func].
+ *
+ *  @param func The suspending function to invoke.
+ *  @param p0 The first parameter.
+ *  @param p1 The second parameter.
+ *  @param p2 The third parameter.
+ */
 suspend fun <T, P0, P1, P2> T.verifyParams(
     func: suspend T.(P0, P1, P2) -> Unit,
     p0: Parameter<P0>,
@@ -113,6 +164,16 @@ suspend fun <T, P0, P1, P2> T.verifyParams(
     func(p0.expected, p1.expected, p2.expected)
 }
 
+/**
+ * Verify that the parameters ([p0], [p1], [p2], [p3]) match for the function call invoked by
+ * [func].
+ *
+ * @param func The function to invoke.
+ * @param p0 The first parameter.
+ * @param p1 The second parameter.
+ * @param p2 The third parameter.
+ * @param p3 The fourth parameter.
+ */
 fun <T, P0, P1, P2, P3> T.verifyParams(
     func: T.(P0, P1, P2, P3) -> Unit,
     p0: Parameter<P0>,
@@ -131,6 +192,16 @@ fun <T, P0, P1, P2, P3> T.verifyParams(
     func(p0.expected, p1.expected, p2.expected, p3.expected)
 }
 
+/**
+ * Verify that the parameters ([p0], [p1], [p2], [p3]) match for the suspending function call
+ * invoked by [func].
+ *
+ *  @param func The suspending function to invoke.
+ *  @param p0 The first parameter.
+ *  @param p1 The second parameter.
+ *  @param p2 The third parameter.
+ *  @param p3 The fourth parameter.
+ */
 suspend fun <T, P0, P1, P2, P3> T.verifyParams(
     func: suspend T.(P0, P1, P2, P3) -> Unit,
     p0: Parameter<P0>,
@@ -149,6 +220,17 @@ suspend fun <T, P0, P1, P2, P3> T.verifyParams(
     func(p0.expected, p1.expected, p2.expected, p3.expected)
 }
 
+/**
+ * Verify that the parameters ([p0], [p1], [p2], [p3], [p4]) match for the function call invoked by
+ * [func].
+ *
+ * @param func The function to invoke.
+ * @param p0 The first parameter.
+ * @param p1 The second parameter.
+ * @param p2 The third parameter.
+ * @param p3 The fourth parameter.
+ * @param p4 The fifth parameter.
+ */
 fun <T, P0, P1, P2, P3, P4> T.verifyParams(
     func: T.(P0, P1, P2, P3, P4) -> Unit,
     p0: Parameter<P0>,
@@ -169,6 +251,16 @@ fun <T, P0, P1, P2, P3, P4> T.verifyParams(
     func(p0.expected, p1.expected, p2.expected, p3.expected, p4.expected)
 }
 
+/**
+ * Verify that the parameters ([p0], [p1], [p2], [p3], [p4]) match for the suspending function call
+ * invoked by [func].
+ *
+ *  @param func The suspending function to invoke.
+ *  @param p0 The first parameter.
+ *  @param p1 The second parameter.
+ *  @param p2 The third parameter.
+ *  @param p3 The fourth parameter.
+ */
 suspend fun <T, P0, P1, P2, P3, P4> T.verifyParams(
     func: suspend T.(P0, P1, P2, P3, P4) -> Unit,
     p0: Parameter<P0>,
@@ -189,6 +281,11 @@ suspend fun <T, P0, P1, P2, P3, P4> T.verifyParams(
     func(p0.expected, p1.expected, p2.expected, p3.expected, p4.expected)
 }
 
+/**
+ * Verify that a function was called without matching any of the parameters.
+ *
+ * @param invocation The function invocation to verify.
+ */
 inline fun <T : Any> T.verifyIgnoreParams(invocation: T.() -> Unit) {
     check(this is Verifiable) { MUST_BE_VERIFIABLE }
     check(this._mockingbird_verifying) { "You can only call verifyIgnoreParams inside a verify block" }

--- a/mockingbird/core/src/main/kotlin/com/anthonycr/mockingbird/core/Verify.kt
+++ b/mockingbird/core/src/main/kotlin/com/anthonycr/mockingbird/core/Verify.kt
@@ -1,4 +1,9 @@
 package com.anthonycr.mockingbird.core
 
+/**
+ * Annotate the property for which you wish to create a fake verification implementation.
+ * Mockingbird will generate a fake implementation for the annotated property. Only interfaces are
+ * supported.
+ */
 @Target(AnnotationTarget.PROPERTY)
 annotation class Verify

--- a/mockingbird/processor/src/main/kotlin/com/anthonycr/mockingbird/processor/MockingbirdSymbolProcessor.kt
+++ b/mockingbird/processor/src/main/kotlin/com/anthonycr/mockingbird/processor/MockingbirdSymbolProcessor.kt
@@ -42,6 +42,7 @@ class MockingbirdSymbolProcessor(
             .map { it.type.resolve().declaration }
             .check("Only interfaces can be verified") { it is KSClassDeclaration && it.classKind == ClassKind.INTERFACE }
             .filterIsInstance<KSClassDeclaration>()
+            .distinctBy { it.qualifiedName!!.asString() }
             .associateBy { it.qualifiedName!!.asString() }
             .map { (name, declaration) ->
                 val fakeTypeSpec = generateFakeImplementation(declaration)

--- a/sample/src/test/kotlin/com/anthonycr/mockingbird/sample/ClassToTestTest.kt
+++ b/sample/src/test/kotlin/com/anthonycr/mockingbird/sample/ClassToTestTest.kt
@@ -3,12 +3,11 @@ package com.anthonycr.mockingbird.sample
 import com.anthonycr.mockingbird.core.Verify
 import com.anthonycr.mockingbird.core.any
 import com.anthonycr.mockingbird.core.eq
-import com.anthonycr.mockingbird.core.sameAs
 import com.anthonycr.mockingbird.core.fake
-import com.anthonycr.mockingbird.core.times
+import com.anthonycr.mockingbird.core.sameAs
 import com.anthonycr.mockingbird.core.verify
+import com.anthonycr.mockingbird.core.verifyComplete
 import com.anthonycr.mockingbird.core.verifyIgnoreParams
-import com.anthonycr.mockingbird.core.verifyNoInvocations
 import com.anthonycr.mockingbird.core.verifyParams
 import kotlinx.coroutines.test.runTest
 import org.junit.Test
@@ -33,8 +32,8 @@ class ClassToTestTest {
             interfaceToVerify2.performAction1(1, "two", "three")
         }
 
-        interfaceToVerify1.verifyNoInvocations()
-        interfaceToVerify2.verifyNoInvocations()
+        interfaceToVerify1.verifyComplete()
+        interfaceToVerify2.verifyComplete()
     }
 
     @Test(expected = IllegalStateException::class)
@@ -62,8 +61,8 @@ class ClassToTestTest {
             interfaceToVerify2.performAction1(2, "three", "four")
         }
 
-        interfaceToVerify1.verifyNoInvocations()
-        interfaceToVerify2.verifyNoInvocations()
+        interfaceToVerify1.verifyComplete()
+        interfaceToVerify2.verifyComplete()
     }
 
     @Test(expected = IllegalStateException::class)
@@ -85,8 +84,10 @@ class ClassToTestTest {
         classToTest.act3()
 
         verify(interfaceToVerify1, interfaceToVerify2) {
-            interfaceToVerify1.times(2) { interfaceToVerify1.performAction1(1) }
-            interfaceToVerify2.times(2) { interfaceToVerify2.performAction1(1, "two", "three") }
+            interfaceToVerify1.performAction1(1)
+            interfaceToVerify1.performAction1(1)
+            interfaceToVerify2.performAction1(1, "two", "three")
+            interfaceToVerify2.performAction1(1, "two", "three")
         }
     }
 
@@ -98,7 +99,9 @@ class ClassToTestTest {
 
         verify(interfaceToVerify1, interfaceToVerify2) {
             // Only invoked 2 times
-            interfaceToVerify1.times(3) { interfaceToVerify1.performAction1(1) }
+            interfaceToVerify1.performAction1(1)
+            interfaceToVerify1.performAction1(1)
+            interfaceToVerify1.performAction1(1)
         }
     }
 
@@ -108,8 +111,8 @@ class ClassToTestTest {
 
         classToTest.act4()
 
-        interfaceToVerify1.verifyNoInvocations()
-        interfaceToVerify2.verifyNoInvocations()
+        interfaceToVerify1.verifyComplete()
+        interfaceToVerify2.verifyComplete()
     }
 
     @Test(expected = IllegalStateException::class)
@@ -119,7 +122,7 @@ class ClassToTestTest {
         classToTest.act3()
 
         // act3 function call actually has invocations
-        interfaceToVerify1.verifyNoInvocations()
+        interfaceToVerify1.verifyComplete()
     }
 
     @Test(expected = IllegalStateException::class)
@@ -142,7 +145,7 @@ class ClassToTestTest {
         classToTest.act3()
 
         verify(interfaceToVerify1) {
-            interfaceToVerify1.verifyNoInvocations()
+            interfaceToVerify1.verifyComplete()
         }
     }
 

--- a/sample/src/test/kotlin/com/anthonycr/mockingbird/sample/ClassToTestTest.kt
+++ b/sample/src/test/kotlin/com/anthonycr/mockingbird/sample/ClassToTestTest.kt
@@ -31,9 +31,6 @@ class ClassToTestTest {
             interfaceToVerify1.performAction1(2)
             interfaceToVerify2.performAction1(1, "two", "three")
         }
-
-        interfaceToVerify1.verifyComplete()
-        interfaceToVerify2.verifyComplete()
     }
 
     @Test(expected = IllegalStateException::class)
@@ -60,9 +57,6 @@ class ClassToTestTest {
             interfaceToVerify2.performAction2()
             interfaceToVerify2.performAction1(2, "three", "four")
         }
-
-        interfaceToVerify1.verifyComplete()
-        interfaceToVerify2.verifyComplete()
     }
 
     @Test(expected = IllegalStateException::class)
@@ -116,13 +110,26 @@ class ClassToTestTest {
     }
 
     @Test(expected = IllegalStateException::class)
-    fun `act4 expected failure`() {
+    fun `act3 expected failure`() {
         val classToTest = ClassToTest(interfaceToVerify1, interfaceToVerify2)
 
         classToTest.act3()
 
         // act3 function call actually has invocations
         interfaceToVerify1.verifyComplete()
+    }
+
+    @Test(expected = IllegalStateException::class)
+    fun `act3 expected failure unverified`() {
+        val classToTest = ClassToTest(interfaceToVerify1, interfaceToVerify2)
+
+        classToTest.act3()
+
+        verify(interfaceToVerify1, interfaceToVerify2) {
+            interfaceToVerify1.performAction1(1)
+            interfaceToVerify1.performAction1(1)
+            interfaceToVerify2.performAction1(1, "two", "three")
+        }
     }
 
     @Test(expected = IllegalStateException::class)

--- a/sample/src/test/kotlin/com/anthonycr/mockingbird/sample/ClassToTestTest.kt
+++ b/sample/src/test/kotlin/com/anthonycr/mockingbird/sample/ClassToTestTest.kt
@@ -99,9 +99,9 @@ class ClassToTestTest {
 
         verify(interfaceToVerify1, interfaceToVerify2) {
             // Only invoked 2 times
-            interfaceToVerify1.performAction1(1)
-            interfaceToVerify1.performAction1(1)
-            interfaceToVerify1.performAction1(1)
+            repeat(3) {
+                interfaceToVerify1.performAction1(1)
+            }
         }
     }
 


### PR DESCRIPTION
The `times` function is not really necessary and complicates the generated code, so better to just leave it out. It's preferable to use Kotlin's `repeat` function instead.