### PR TITLE
Add verifyPartial to allow partial verification of invocations

### DIFF
--- a/mockingbird/core/src/main/kotlin/com/anthonycr/mockingbird/core/Verifiable.kt
+++ b/mockingbird/core/src/main/kotlin/com/anthonycr/mockingbird/core/Verifiable.kt
@@ -52,7 +52,7 @@ inline fun verifyPartial(vararg verifiable: Any, block: () -> Unit) {
     }
 
     verifiableList.forEach {
-        check(!it._mockingbird_verifying) { "Do not call verify within another verify block" }
+        check(!it._mockingbird_verifying) { "Do not call verifyPartial within another verify block" }
         it._mockingbird_verifying = true
     }
     block()

--- a/mockingbird/core/src/main/kotlin/com/anthonycr/mockingbird/core/Verifiable.kt
+++ b/mockingbird/core/src/main/kotlin/com/anthonycr/mockingbird/core/Verifiable.kt
@@ -20,7 +20,7 @@ interface Verifiable {
  * Verifies the [verifiable] and invokes the [block], in which to call functions on the [verifiable]
  * that are expected to be called. All expected invocations must be verified within the [block].
  *
- * This function cannot be called within another [verify] block.
+ * This function cannot be called within another [verify] or [verifyPartial] block.
  */
 inline fun verify(vararg verifiable: Any, block: () -> Unit) {
     val verifiableList: List<Verifiable> = verifiable.map {
@@ -43,7 +43,7 @@ inline fun verify(vararg verifiable: Any, block: () -> Unit) {
  * Verifies the [verifiable] and invokes the [block], in which to call functions on the [verifiable]
  * that are expected to be called. Unlike [verify] not all invocations need to be verified.
  *
- * This function cannot be called within another [verify] block.
+ * This function cannot be called within another [verify] or [verifyPartial] block.
  */
 inline fun verifyPartial(vararg verifiable: Any, block: () -> Unit) {
     val verifiableList: List<Verifiable> = verifiable.map {

--- a/mockingbird/core/src/main/kotlin/com/anthonycr/mockingbird/core/Verifiable.kt
+++ b/mockingbird/core/src/main/kotlin/com/anthonycr/mockingbird/core/Verifiable.kt
@@ -40,6 +40,29 @@ inline fun verify(vararg verifiable: Any, block: () -> Unit) {
 }
 
 /**
+ * Verifies the [verifiable] and invokes the [block], in which to call functions on the [verifiable]
+ * that are expected to be called. Unlike [verify] not all invocations need to be verified.
+ *
+ * This function cannot be called within another [verify] block.
+ */
+inline fun verifyPartial(vararg verifiable: Any, block: () -> Unit) {
+    val verifiableList: List<Verifiable> = verifiable.map {
+        check(it is Verifiable) { MUST_BE_VERIFIABLE }
+        it
+    }
+
+    verifiableList.forEach {
+        check(!it._mockingbird_verifying) { "Do not call verify within another verify block" }
+        it._mockingbird_verifying = true
+    }
+    block()
+    verifiableList.forEach {
+        it._mockingbird_invocations.clear()
+        it._mockingbird_verifying = false
+    }
+}
+
+/**
  * Verifies that all expected function invocations have been verified. Useful if there are no
  * invocations expected for a certain verifiable.
  *

--- a/sample/src/test/kotlin/com/anthonycr/mockingbird/sample/ClassToTestTest.kt
+++ b/sample/src/test/kotlin/com/anthonycr/mockingbird/sample/ClassToTestTest.kt
@@ -9,6 +9,7 @@ import com.anthonycr.mockingbird.core.verify
 import com.anthonycr.mockingbird.core.verifyComplete
 import com.anthonycr.mockingbird.core.verifyIgnoreParams
 import com.anthonycr.mockingbird.core.verifyParams
+import com.anthonycr.mockingbird.core.verifyPartial
 import kotlinx.coroutines.test.runTest
 import org.junit.Test
 
@@ -145,6 +146,20 @@ class ClassToTestTest {
         classToTest.act3()
 
         verify(interfaceToVerify1, interfaceToVerify2) {
+            interfaceToVerify1.performAction1(1)
+            interfaceToVerify1.performAction1(1)
+            interfaceToVerify2.performAction1(1, "two", "three")
+        }
+    }
+
+    @Test
+    fun `act3 passes with unverified using verifyPartial`() {
+        val classToTest =
+            ClassToTest(lambdaToVerify1, lambdaToVerify2, interfaceToVerify1, interfaceToVerify2)
+
+        classToTest.act3()
+
+        verifyPartial(interfaceToVerify1, interfaceToVerify2) {
             interfaceToVerify1.performAction1(1)
             interfaceToVerify1.performAction1(1)
             interfaceToVerify2.performAction1(1, "two", "three")


### PR DESCRIPTION
Creates `verifyPartial` function to provide alternative to `verify` and `verifyComplete` requiring all invocations to be verified.

Closes #64 