### PR TITLE
Release 1.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # CHANGELOG
 
+## 1.3.0 *(17 December 2024)*
+- Improve usability by allowing import of `fake` function before it's generated.
+- Fix issue where usage of the `fake` function like `val fake = fake<Type>()` would not compile.
+- Fix issue where usage of the `fake` function like `val fake = fake(Type::class.java)` would not compile.
+
 ## 1.2.0 *(15 September 2024)*
 - Add support for `verifyPartial` to allow for verifying only some invocations.
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -7,7 +7,7 @@ ksp.useKSP2=true
 
 # Publishing
 GROUP=com.anthonycr.mockingbird
-VERSION_NAME=1.2.0
+VERSION_NAME=1.3.0
 
 POM_NAME=Mockingbird
 POM_DESCRIPTION=A minimalist faking framework exclusively for verifying interactions


### PR DESCRIPTION
- Improve usability by allowing import of `fake` function before it's generated.
- Fix issue where usage of the `fake` function like `val fake = fake<Type>()` would not compile.
- Fix issue where usage of the `fake` function like `val fake = fake(Type::class.java)` would not compile.