### PR TITLE
Lower Language level to be compatible with Kotlin 1.9

### DIFF
--- a/mockingbird/core/build.gradle.kts
+++ b/mockingbird/core/build.gradle.kts
@@ -1,5 +1,6 @@
 import com.vanniktech.maven.publish.SonatypeHost
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget
+import org.jetbrains.kotlin.gradle.dsl.KotlinVersion
 
 plugins {
     kotlin("multiplatform")
@@ -9,7 +10,10 @@ plugins {
 kotlin {
     jvmToolchain(libs.versions.jvm.get().toInt())
     jvm {
-        compilerOptions.jvmTarget.set(JvmTarget.JVM_11)
+        compilerOptions {
+            jvmTarget.set(JvmTarget.JVM_11)
+            languageVersion.set(KotlinVersion.KOTLIN_2_0)
+        }
     }
 }
 

--- a/mockingbird/internal/build.gradle.kts
+++ b/mockingbird/internal/build.gradle.kts
@@ -1,4 +1,5 @@
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget
+import org.jetbrains.kotlin.gradle.dsl.KotlinVersion
 
 plugins {
     kotlin("multiplatform")
@@ -7,9 +8,11 @@ plugins {
 kotlin {
     jvmToolchain(libs.versions.jvm.get().toInt())
     jvm {
-        compilerOptions.jvmTarget.set(JvmTarget.JVM_11)
-    }
-}
+        compilerOptions {
+            jvmTarget.set(JvmTarget.JVM_11)
+            languageVersion.set(KotlinVersion.KOTLIN_2_0)
+        }
+    }}
 
 java {
     targetCompatibility = JavaVersion.VERSION_11

--- a/mockingbird/processor/build.gradle.kts
+++ b/mockingbird/processor/build.gradle.kts
@@ -1,4 +1,5 @@
 import com.vanniktech.maven.publish.SonatypeHost
+import org.jetbrains.kotlin.gradle.dsl.KotlinVersion
 
 plugins {
     kotlin("jvm")
@@ -7,6 +8,9 @@ plugins {
 
 kotlin {
     jvmToolchain(libs.versions.jvm.get().toInt())
+    compilerOptions {
+        languageVersion.set(KotlinVersion.KOTLIN_2_0)
+    }
 }
 
 dependencies {


### PR DESCRIPTION
This PR just lowers the language version to 2.0 to allow projects stuck on Kotlin 1.9 (🙈) to use the latest version of Mockingbird. 