### PR TITLE
Determine error location and log the location in the KSP error log

### DIFF
--- a/mockingbird/processor/src/main/kotlin/com/anthonycr/mockingbird/processor/internal/errors.kt
+++ b/mockingbird/processor/src/main/kotlin/com/anthonycr/mockingbird/processor/internal/errors.kt
@@ -1,7 +1,9 @@
 package com.anthonycr.mockingbird.processor.internal
 
 import com.google.devtools.ksp.processing.KSPLogger
+import com.google.devtools.ksp.symbol.FileLocation
 import com.google.devtools.ksp.symbol.KSNode
+import com.google.devtools.ksp.symbol.NonExistLocation
 
 /**
  * Check the provided [condition] and only allow the items through that pass.
@@ -15,7 +17,12 @@ fun <T> Sequence<T>.check(
     val passed = condition(it)
 
     if (!passed) {
-        logger.error(message, node(it))
+        val realNode = node(it)
+        val actualMessage = when (val location = realNode.location) {
+            is FileLocation -> "$message: ${location.filePath}:${location.lineNumber}"
+            NonExistLocation -> message
+        }
+        logger.error(actualMessage, node(it))
     }
 
     passed

--- a/mockingbird/processor/src/test/kotlin/com/anthonycr/mockingbird/processor/MockingbirdSymbolProcessorTest.kt
+++ b/mockingbird/processor/src/test/kotlin/com/anthonycr/mockingbird/processor/MockingbirdSymbolProcessorTest.kt
@@ -41,7 +41,7 @@ class MockingbirdSymbolProcessorTest {
         val result = compile(listOf(nonInterfaceAnnotatedSource))
 
         Assert.assertEquals(KotlinCompilation.ExitCode.COMPILATION_ERROR, result.exitCode)
-        Assert.assertTrue(result.messages.contains("/Test2.kt:5: Only interfaces can be verified"))
+        Assert.assertTrue(result.messages.contains(Regex("\\s.*/Test2.kt:13: Only interfaces can be verified:\\s.*/Test2.kt:13")))
     }
 
     @Test


### PR DESCRIPTION
The `KSPLogger` doesn't seem to mark the location properly in the output logs, although it does seem to do it properly in testing, so I just added the location to the logs directly.

Closes #104 