### PR TITLE
Improve incremental compilation

### DIFF
--- a/mockingbird/processor/src/main/kotlin/com/anthonycr/mockingbird/processor/MockingbirdSymbolProcessor.kt
+++ b/mockingbird/processor/src/main/kotlin/com/anthonycr/mockingbird/processor/MockingbirdSymbolProcessor.kt
@@ -2,7 +2,7 @@ package com.anthonycr.mockingbird.processor
 
 import com.anthonycr.mockingbird.core.Verify
 import com.anthonycr.mockingbird.processor.internal.check
-import com.anthonycr.mockingbird.processor.internal.data.KSClassDeclarationKey
+import com.anthonycr.mockingbird.processor.internal.data.asKey
 import com.anthonycr.mockingbird.processor.internal.generator.FakeFunctionGenerator
 import com.anthonycr.mockingbird.processor.internal.generator.FakeImplementationGenerator
 import com.anthonycr.mockingbird.processor.internal.isInterface
@@ -11,7 +11,6 @@ import com.google.devtools.ksp.processing.KSPLogger
 import com.google.devtools.ksp.processing.Resolver
 import com.google.devtools.ksp.processing.SymbolProcessor
 import com.google.devtools.ksp.symbol.KSAnnotated
-import com.google.devtools.ksp.symbol.KSClassDeclaration
 import com.google.devtools.ksp.symbol.KSPropertyDeclaration
 import com.squareup.kotlinpoet.ksp.writeTo
 
@@ -41,9 +40,7 @@ class MockingbirdSymbolProcessor(
                 condition = { (_, resolvedDeclaration) -> resolvedDeclaration.isInterface }
             )
             .groupBy(
-                keySelector = { (_, resolvedDeclaration) ->
-                    KSClassDeclarationKey(resolvedDeclaration as KSClassDeclaration)
-                },
+                keySelector = { (_, resolvedDeclaration) -> resolvedDeclaration.asKey() },
                 valueTransform = { (propertyDeclaration, _) -> propertyDeclaration }
             )
             .map { (resolvedDeclarationKey, propertyDeclarations) ->

--- a/mockingbird/processor/src/main/kotlin/com/anthonycr/mockingbird/processor/internal/data/KSClassDeclarationKey.kt
+++ b/mockingbird/processor/src/main/kotlin/com/anthonycr/mockingbird/processor/internal/data/KSClassDeclarationKey.kt
@@ -1,6 +1,7 @@
 package com.anthonycr.mockingbird.processor.internal.data
 
 import com.google.devtools.ksp.symbol.KSClassDeclaration
+import com.google.devtools.ksp.symbol.KSDeclaration
 
 /**
  * A wrapper for [KSClassDeclaration] that allows it to be safely used as a key in a map or set.
@@ -27,3 +28,9 @@ data class KSClassDeclarationKey(
 
     override fun toString(): String = "KSClassDeclarationKey(key='$key')"
 }
+
+/**
+ * Convert the [KSDeclaration] to a [KSClassDeclarationKey].
+ */
+fun KSDeclaration.asKey(): KSClassDeclarationKey =
+    KSClassDeclarationKey(this as KSClassDeclaration)

--- a/mockingbird/processor/src/main/kotlin/com/anthonycr/mockingbird/processor/internal/data/KSClassDeclarationKey.kt
+++ b/mockingbird/processor/src/main/kotlin/com/anthonycr/mockingbird/processor/internal/data/KSClassDeclarationKey.kt
@@ -1,0 +1,29 @@
+package com.anthonycr.mockingbird.processor.internal.data
+
+import com.google.devtools.ksp.symbol.KSClassDeclaration
+
+/**
+ * A wrapper for [KSClassDeclaration] that allows it to be safely used as a key in a map or set.
+ *
+ * @property ksClassDeclaration The underlying [KSClassDeclaration].
+ * @property key The key derived from [ksClassDeclaration].
+ */
+data class KSClassDeclarationKey(
+    val ksClassDeclaration: KSClassDeclaration
+) {
+    val key: String
+        get() = ksClassDeclaration.qualifiedName!!.asString()
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (javaClass != other?.javaClass) return false
+
+        other as KSClassDeclarationKey
+
+        return key == other.key
+    }
+
+    override fun hashCode(): Int = key.hashCode()
+
+    override fun toString(): String = "KSClassDeclarationKey(key='$key')"
+}

--- a/mockingbird/processor/src/main/kotlin/com/anthonycr/mockingbird/processor/internal/generator/FakeFunctionGenerator.kt
+++ b/mockingbird/processor/src/main/kotlin/com/anthonycr/mockingbird/processor/internal/generator/FakeFunctionGenerator.kt
@@ -3,13 +3,14 @@ package com.anthonycr.mockingbird.processor.internal.generator
 import com.anthonycr.mockingbird.processor.internal.normalizedQualifiedName
 import com.anthonycr.mockingbird.processor.internal.safePackageName
 import com.google.devtools.ksp.symbol.KSClassDeclaration
+import com.google.devtools.ksp.symbol.KSPropertyDeclaration
 import com.squareup.kotlinpoet.ClassName
 import com.squareup.kotlinpoet.FileSpec
 import com.squareup.kotlinpoet.FunSpec
-import com.squareup.kotlinpoet.KModifier
 import com.squareup.kotlinpoet.ParameterizedTypeName.Companion.parameterizedBy
 import com.squareup.kotlinpoet.TypeSpec
 import com.squareup.kotlinpoet.TypeVariableName
+import com.squareup.kotlinpoet.ksp.addOriginatingKSFile
 
 /**
  * Used to generate the fake function used to obtain the generated fake implementation.
@@ -20,26 +21,33 @@ class FakeFunctionGenerator {
      * Generate the fake function from the [KSClassDeclaration] and associated [TypeSpec] for each
      * fake interface.
      */
-    fun generate(fakeImplementations: Map<KSClassDeclaration, TypeSpec>): FileSpec =
-        FileSpec.builder("com.anthonycr.mockingbird.core", "FakesInternal")
-            .addFunction(
-                FunSpec.builder("fakeInternal")
-                    .addTypeVariable(TypeVariableName("T"))
-                    .addParameter(
-                        "clazz",
-                        ClassName("java.lang", "Class").parameterizedBy(TypeVariableName("T"))
-                    )
-                    .returns(TypeVariableName("T"))
-                    .beginControlFlow("return when(clazz.canonicalName)")
-                    .apply {
-                        fakeImplementations.forEach { (declaration, fake) ->
-                            val className =
-                                ClassName(declaration.safePackageName, fake.name!!)
-                            addStatement("\"${declaration.normalizedQualifiedName}\" -> clazz.cast(${className.canonicalName}())!!")
+    fun generate(
+        fakeImplementations: List<Triple<List<KSPropertyDeclaration>, KSClassDeclaration, TypeSpec>>
+    ): FileSpec = FileSpec.builder("com.anthonycr.mockingbird.core", "FakesInternal")
+        .addFunction(
+            FunSpec.builder("fakeInternal")
+                .addTypeVariable(TypeVariableName("T"))
+                .addParameter(
+                    "clazz",
+                    ClassName("java.lang", "Class").parameterizedBy(TypeVariableName("T"))
+                )
+                .returns(TypeVariableName("T"))
+                .beginControlFlow("return when(clazz.canonicalName)")
+                .apply {
+                    fakeImplementations.forEach { (properties, declaration, fake) ->
+                        properties.mapNotNull { it.containingFile }.forEach {
+                            addOriginatingKSFile(it)
                         }
-                        addStatement("else -> error(\"Unsupported type \$clazz\")")
+                        declaration.containingFile?.let {
+                            addOriginatingKSFile(it)
+                        }
+                        val className =
+                            ClassName(declaration.safePackageName, fake.name!!)
+                        addStatement("\"${declaration.normalizedQualifiedName}\" -> clazz.cast(${className.canonicalName}())!!")
                     }
-                    .endControlFlow()
-                    .build()
-            ).build()
+                    addStatement("else -> error(\"Unsupported type \$clazz\")")
+                }
+                .endControlFlow()
+                .build()
+        ).build()
 }


### PR DESCRIPTION
Improve incremental compilation by utilizing `addOriginatingKSFile`. Otherwise we can get into scenarios where source file changes don't result in the code being generated.