### PR TITLE
Improve error messaging when KSP plugin isn't applied

### DIFF
--- a/mockingbird/core/build.gradle.kts
+++ b/mockingbird/core/build.gradle.kts
@@ -23,6 +23,8 @@ java {
 }
 dependencies {
     commonMainCompileOnly(project(":mockingbird:internal"))
+
+    commonTestImplementation(libs.junit)
 }
 
 mavenPublishing {

--- a/mockingbird/core/src/commonMain/kotlin/com/anthonycr/mockingbird/core/Fakes.kt
+++ b/mockingbird/core/src/commonMain/kotlin/com/anthonycr/mockingbird/core/Fakes.kt
@@ -8,4 +8,11 @@ inline fun <reified T> fake(): T = fake(T::class.java)
 /**
  * Create a fake implementation of type [clazz].
  */
-fun <T> fake(clazz: Class<T>): T = fakeInternal(clazz)
+fun <T> fake(clazz: Class<T>): T = try {
+    fakeInternal(clazz)
+} catch (noClassDefFoundError: NoClassDefFoundError) {
+    throw RuntimeException(
+        "Generated code is missing. Please apply the KSP plugin and add `kspTest(com.anthonycr.mockingbird:processor:<latest_version>)` as a dependency.",
+        noClassDefFoundError
+    )
+}

--- a/mockingbird/core/src/commonTest/kotlin/com/anthonycr/mockingbird/core/FakesKtTest.kt
+++ b/mockingbird/core/src/commonTest/kotlin/com/anthonycr/mockingbird/core/FakesKtTest.kt
@@ -1,0 +1,16 @@
+package com.anthonycr.mockingbird.core
+
+import org.junit.Test
+
+class FakesKtTest {
+
+    @Test(expected = RuntimeException::class)
+    fun `inline fake throws exception when there is no ksp dependency`() {
+        fake<Unit>()
+    }
+
+    @Test(expected = RuntimeException::class)
+    fun `fake throws exception when there is no ksp dependency`() {
+        fake(Unit::class.java)
+    }
+}


### PR DESCRIPTION
When the KSP plugin and the `kspTest` dependency on mockingbird isn't applied, the `fake` function will throw an exception. This seems to be a common issue, so I'm catching the exception that can be thrown and re-throwing it with a more helpful error message.