### PR TITLE
Support non-public interfaces/data types in Mockingbird

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -13,6 +13,7 @@ kotlinpoet-ksp = { group = "com.squareup", name = "kotlinpoet-ksp", version.ref 
 compiletesting = { group = "dev.zacsweers.kctfork", name = "ksp", version = "0.11.0" }
 mockk = { group = "io.mockk", name = "mockk", version = "1.14.6" }
 coroutines-test = { group = "org.jetbrains.kotlinx", name = "kotlinx-coroutines-test", version = "1.10.2" }
+kotlin-reflect = { group = "org.jetbrains.kotlin", name = "kotlin-reflect", version.ref = "jetbrainsKotlin" }
 
 [plugins]
 ksp-plugin = { id = "com.google.devtools.ksp", version.ref = "ksp" }

--- a/mockingbird/processor/build.gradle.kts
+++ b/mockingbird/processor/build.gradle.kts
@@ -20,6 +20,7 @@ dependencies {
 
     testImplementation(libs.compiletesting)
     testImplementation(libs.junit)
+    testImplementation(libs.kotlin.reflect)
 }
 
 mavenPublishing {

--- a/mockingbird/processor/src/main/kotlin/com/anthonycr/mockingbird/processor/MockingbirdSymbolProcessor.kt
+++ b/mockingbird/processor/src/main/kotlin/com/anthonycr/mockingbird/processor/MockingbirdSymbolProcessor.kt
@@ -7,6 +7,7 @@ import com.anthonycr.mockingbird.processor.internal.generator.FakeFunctionGenera
 import com.anthonycr.mockingbird.processor.internal.generator.FakeImplementationGenerator
 import com.anthonycr.mockingbird.processor.internal.isInterface
 import com.google.devtools.ksp.getConstructors
+import com.google.devtools.ksp.getVisibility
 import com.google.devtools.ksp.isAbstract
 import com.google.devtools.ksp.processing.CodeGenerator
 import com.google.devtools.ksp.processing.KSPLogger
@@ -15,6 +16,7 @@ import com.google.devtools.ksp.processing.SymbolProcessor
 import com.google.devtools.ksp.symbol.KSAnnotated
 import com.google.devtools.ksp.symbol.KSClassDeclaration
 import com.google.devtools.ksp.symbol.KSPropertyDeclaration
+import com.google.devtools.ksp.symbol.Visibility
 import com.squareup.kotlinpoet.ksp.writeTo
 
 class MockingbirdSymbolProcessor(
@@ -44,6 +46,12 @@ class MockingbirdSymbolProcessor(
                     resolvedDeclaration is KSClassDeclaration &&
                             (resolvedDeclaration.isInterface || resolvedDeclaration.isAbstract())
                 }
+            )
+            .check(
+                message = "Package private Java files cannot be verified, please update the visibility modifier to public",
+                logger = logger,
+                node = { (declaration, _) -> declaration },
+                condition = { (_, resolvedDeclaration) -> resolvedDeclaration.getVisibility() != Visibility.JAVA_PACKAGE }
             )
             .filterIsInstance<Pair<KSPropertyDeclaration, KSClassDeclaration>>()
             .check(

--- a/mockingbird/processor/src/test/kotlin/com/anthonycr/mockingbird/processor/MockingbirdSymbolProcessorTest.kt
+++ b/mockingbird/processor/src/test/kotlin/com/anthonycr/mockingbird/processor/MockingbirdSymbolProcessorTest.kt
@@ -9,6 +9,7 @@ import org.junit.Assert
 import org.junit.Rule
 import org.junit.Test
 import org.junit.rules.TemporaryFolder
+import kotlin.reflect.KVisibility
 
 @OptIn(ExperimentalCompilerApi::class)
 class MockingbirdSymbolProcessorTest {
@@ -85,5 +86,24 @@ class MockingbirdSymbolProcessorTest {
 
         Assert.assertEquals(KotlinCompilation.ExitCode.COMPILATION_ERROR, result.exitCode)
         Assert.assertTrue(result.messages.contains(Regex("\\s.*/Test8.kt:12: Only abstract classes with zero argument constructors can be verified:\\s.*/Test8.kt:12")))
+    }
+
+    @Test
+    fun `attempting to fake package private java file fails to compile`() {
+        val result = compile(packagePrivateJavaSrc)
+
+        Assert.assertEquals(KotlinCompilation.ExitCode.COMPILATION_ERROR, result.exitCode)
+        Assert.assertTrue(result.messages.contains(Regex("\\s.*/Test9.kt:10: Package private Java files cannot be verified, please update the visibility modifier to public:\\s.*/Test9.kt:10")))
+    }
+
+    @Test
+    fun `faked internal class carries over visibility modifier to generated fake`() {
+        val result = compile(fakedInternalClassCarriesOverModifier)
+
+        Assert.assertEquals(KotlinCompilation.ExitCode.OK, result.exitCode)
+
+        val generatedFake = result.classLoader.loadClass("com.anthonycr.test.feature.FeatureAnalytics_Fake").kotlin
+
+        Assert.assertEquals(generatedFake.visibility, KVisibility.INTERNAL)
     }
 }

--- a/mockingbird/processor/src/test/kotlin/com/anthonycr/mockingbird/processor/TestSources.kt
+++ b/mockingbird/processor/src/test/kotlin/com/anthonycr/mockingbird/processor/TestSources.kt
@@ -131,3 +131,54 @@ val invalidAbstractClassWithConstructorParameters = SourceFile.kotlin("Test8.kt"
     }
 """.trimIndent())
 
+val packagePrivateJavaSrc = listOf(
+    SourceFile.java(
+        "FeatureAnalytics.java", """
+    package com.anthonycr.test.feature;
+    
+    interface FeatureAnalytics {
+        void trackEvent(String event);
+    }
+""".trimIndent()
+    ), SourceFile.kotlin(
+        "Test9.kt", """
+        package com.anthonycr.test
+        
+        import com.anthonycr.mockingbird.core.fake
+        import com.anthonycr.mockingbird.core.Verify
+        import com.anthonycr.test.feature.FeatureAnalytics
+        
+        class Test {
+        
+            @Verify
+            private val featureAnalytics = fake<FeatureAnalytics>()
+        }
+    """.trimIndent()
+    )
+)
+
+val fakedInternalClassCarriesOverModifier = listOf(
+    SourceFile.kotlin(
+        "FeatureAnalytics.kt", """
+    package com.anthonycr.test.feature
+    
+    internal interface FeatureAnalytics {
+         fun trackEvent(event: String)
+    }
+""".trimIndent()
+    ), SourceFile.kotlin(
+        "Test9.kt", """
+        package com.anthonycr.test
+        
+        import com.anthonycr.mockingbird.core.fake
+        import com.anthonycr.mockingbird.core.Verify
+        import com.anthonycr.test.feature.FeatureAnalytics
+        
+        internal class Test {
+        
+            @Verify
+            private val featureAnalytics = fake<FeatureAnalytics>()
+        }
+    """.trimIndent()
+    )
+)


### PR DESCRIPTION
~~Still WIP~~ 

Ran into this in a hobby project but I wanted to using Mockingbird to verify an interface function that takes an `internal` DTO got this failure:
```
e: file:///Users/nicholasdoglio/Projects/YahooFantasyReporting/app/build/generated/ksp/test/kotlin/dev/whosnickdoglio/yahoofantasy/reporting/sheets/GoogleSheets_Fake.kt:15:35 'public' function exposes its 'internal' parameter type argument 'GoogleSheetsTeamReport'.
```

More concretely I want to be able to support verifying stuff like this: 

```kotlin
internal interface ApiClient {
    fun send(apiData: ApiData)
}

internal data class ApiData(
    val string: String
)
```



