### PR TITLE
Switch to AssertJ for assertions

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -7,6 +7,7 @@ jvm = "17"
 
 [libraries]
 junit = { group = "junit", name = "junit", version.ref = "junit" }
+assertj = { group = "org.assertj", name = "assertj-core", version = "3.27.6" }
 ksp-api = { group = "com.google.devtools.ksp", name = "symbol-processing-api", version.ref = "ksp" }
 kotlinpoet = { group = "com.squareup", name = "kotlinpoet", version.ref = "kotlinpoet" }
 kotlinpoet-ksp = { group = "com.squareup", name = "kotlinpoet-ksp", version.ref = "kotlinpoet" }

--- a/mockingbird/processor/build.gradle.kts
+++ b/mockingbird/processor/build.gradle.kts
@@ -21,6 +21,7 @@ dependencies {
     testImplementation(libs.compiletesting)
     testImplementation(libs.junit)
     testImplementation(libs.kotlin.reflect)
+    testImplementation(libs.assertj)
 }
 
 mavenPublishing {

--- a/mockingbird/processor/src/test/kotlin/com/anthonycr/mockingbird/processor/MockingbirdSymbolProcessorTest.kt
+++ b/mockingbird/processor/src/test/kotlin/com/anthonycr/mockingbird/processor/MockingbirdSymbolProcessorTest.kt
@@ -3,9 +3,9 @@ package com.anthonycr.mockingbird.processor
 import com.tschuchort.compiletesting.KotlinCompilation
 import com.tschuchort.compiletesting.SourceFile
 import com.tschuchort.compiletesting.configureKsp
+import org.assertj.core.api.Assertions.assertThat
 import org.jetbrains.kotlin.compiler.plugin.ExperimentalCompilerApi
 import org.jetbrains.kotlin.config.JvmTarget
-import org.junit.Assert
 import org.junit.Rule
 import org.junit.Test
 import org.junit.rules.TemporaryFolder
@@ -33,77 +33,77 @@ class MockingbirdSymbolProcessorTest {
     fun `non property annotated fails to compile`() {
         val result = compile(listOf(nonPropertyAnnotatedSource))
 
-        Assert.assertEquals(KotlinCompilation.ExitCode.COMPILATION_ERROR, result.exitCode)
-        Assert.assertTrue(result.messages.contains("/Test1.kt:7: Only properties can be annotated with Verify"))
+        assertThat(result.exitCode).isEqualTo(KotlinCompilation.ExitCode.COMPILATION_ERROR)
+        assertThat(result.messages).containsPattern("/Test1.kt:7: Only properties can be annotated with Verify")
     }
 
     @Test
     fun `annotated class property fails to compile`() {
         val result = compile(listOf(nonInterfaceAnnotatedSource))
 
-        Assert.assertEquals(KotlinCompilation.ExitCode.COMPILATION_ERROR, result.exitCode)
-        Assert.assertTrue(result.messages.contains(Regex("\\s.*/Test2.kt:13: Only interfaces and abstract classes can be verified:\\s.*/Test2.kt:13")))
+        assertThat(result.exitCode).isEqualTo(KotlinCompilation.ExitCode.COMPILATION_ERROR)
+        assertThat(result.messages).containsPattern("\\s.*/Test2.kt:13: Only interfaces and abstract classes can be verified:\\s.*/Test2.kt:13")
     }
 
     @Test
     fun `annotated simple interface compiles successfully`() {
         val result = compile(listOf(validInterfaceAnnotatedSource))
 
-        Assert.assertEquals(KotlinCompilation.ExitCode.OK, result.exitCode)
+        assertThat(result.exitCode).isEqualTo(KotlinCompilation.ExitCode.OK)
     }
 
     @Test
     fun `annotated immutable property of simple interface compiles successfully`() {
         val result = compile(listOf(validInterfaceAnnotatedImmutableProperty))
 
-        Assert.assertEquals(KotlinCompilation.ExitCode.OK, result.exitCode)
+        assertThat(result.exitCode).isEqualTo(KotlinCompilation.ExitCode.OK)
     }
 
     @Test
     fun `annotated lambda property compiles successfully`() {
         val result = compile(listOf(validFunctionReferenceAnnotatedSource))
 
-        Assert.assertEquals(KotlinCompilation.ExitCode.OK, result.exitCode)
+        assertThat(result.exitCode).isEqualTo(KotlinCompilation.ExitCode.OK)
     }
 
     @Test
     fun `abstract class with abstract function compiles successfully`() {
         val result = compile(listOf(validAbstractClassOneFunction))
 
-        Assert.assertEquals(KotlinCompilation.ExitCode.OK, result.exitCode)
+        assertThat(result.exitCode).isEqualTo(KotlinCompilation.ExitCode.OK)
     }
 
     @Test
     fun `abstract class with abstract function and real function compiles successfully`() {
         val result = compile(listOf(validAbstractClassRealAndAbstractFunction))
 
-        Assert.assertEquals(KotlinCompilation.ExitCode.OK, result.exitCode)
+        assertThat(result.exitCode).isEqualTo(KotlinCompilation.ExitCode.OK)
     }
 
     @Test
     fun `abstract class with constructor parameters fails to compile`() {
         val result = compile(listOf(invalidAbstractClassWithConstructorParameters))
 
-        Assert.assertEquals(KotlinCompilation.ExitCode.COMPILATION_ERROR, result.exitCode)
-        Assert.assertTrue(result.messages.contains(Regex("\\s.*/Test8.kt:12: Only abstract classes with zero argument constructors can be verified:\\s.*/Test8.kt:12")))
+        assertThat(result.exitCode).isEqualTo(KotlinCompilation.ExitCode.COMPILATION_ERROR)
+        assertThat(result.messages).containsPattern("\\s.*/Test8.kt:12: Only abstract classes with zero argument constructors can be verified:\\s.*/Test8.kt:12")
     }
 
     @Test
     fun `attempting to fake package private java file fails to compile`() {
         val result = compile(packagePrivateJavaSrc)
 
-        Assert.assertEquals(KotlinCompilation.ExitCode.COMPILATION_ERROR, result.exitCode)
-        Assert.assertTrue(result.messages.contains(Regex("\\s.*/Test9.kt:10: Package private Java files cannot be verified, please update the visibility modifier to public:\\s.*/Test9.kt:10")))
+        assertThat(result.exitCode).isEqualTo(KotlinCompilation.ExitCode.COMPILATION_ERROR)
+        assertThat(result.messages).containsPattern("\\s.*/Test9.kt:10: Package private Java files cannot be verified, please update the visibility modifier to public:\\s.*/Test9.kt:10")
     }
 
     @Test
     fun `faked internal class carries over visibility modifier to generated fake`() {
         val result = compile(fakedInternalClassCarriesOverModifier)
 
-        Assert.assertEquals(KotlinCompilation.ExitCode.OK, result.exitCode)
+        assertThat(result.exitCode).isEqualTo(KotlinCompilation.ExitCode.OK)
 
         val generatedFake = result.classLoader.loadClass("com.anthonycr.test.feature.FeatureAnalytics_Fake").kotlin
 
-        Assert.assertEquals(generatedFake.visibility, KVisibility.INTERNAL)
+        assertThat(generatedFake.visibility).isEqualTo(KVisibility.INTERNAL)
     }
 }


### PR DESCRIPTION
It was very rude of you to force me to use `org.junit.Assert` after we talked about how good assertion libraries were the other day. 

Switched the tests to use AssertJ but fine with switching to something else if that's preferred