### PR TITLE
Update error message format to allow intellij to show difference

### DIFF
--- a/mockingbird/processor/src/main/kotlin/com/anthonycr/mockingbird/processor/internal/generator/FakeImplementationGenerator.kt
+++ b/mockingbird/processor/src/main/kotlin/com/anthonycr/mockingbird/processor/internal/generator/FakeImplementationGenerator.kt
@@ -165,7 +165,7 @@ class FakeImplementationGenerator {
                 .addStatement("_mockingbird_invocations.removeAt(0)")
                 .beginControlFlow("check(invocation.functionName == %S)", functionName)
                 .addStatement(
-                    "\"Expected function call %1L, \${invocation.functionName} was called instead\"",
+                    "\"expected: < FUNCTION_CALL: %1L> but was: < FUNCTION_CALL: \${invocation.functionName}>\"",
                     functionName,
                 )
                 .endControlFlow()
@@ -184,7 +184,7 @@ class FakeImplementationGenerator {
                             name
                         )
                         addStatement(
-                            "\"Expected argument \$%1L, found \${invocation.parameters[%2L]} instead.\"",
+                            "\"expected: < ARGUMENT $index: $%1L> but was: < ARGUMENT $index: \${invocation.parameters[%2L]}>\"",
                             name,
                             index
                         )

--- a/sample/src/test/kotlin/com/anthonycr/mockingbird/sample/ClassToTestTest.kt
+++ b/sample/src/test/kotlin/com/anthonycr/mockingbird/sample/ClassToTestTest.kt
@@ -54,7 +54,7 @@ class ClassToTestTest {
 
     @Test
     fun `act1 expected failure`() {
-        assertThrows<IllegalStateException>("Expected argument 2, found 1 instead.") {
+        assertThrows<IllegalStateException>("expected: < ARGUMENT 0: 2> but was: < ARGUMENT 0: 1>") {
             val classToTest = createClassToTest()
 
             classToTest.act1()
@@ -83,7 +83,7 @@ class ClassToTestTest {
 
     @Test
     fun `act2 expected failure`() {
-        assertThrows<IllegalStateException>("Expected function call com.anthonycr.mockingbird.sample.InterfaceToVerify1.performAction1, com.anthonycr.mockingbird.sample.InterfaceToVerify1.performAction2 was called instead") {
+        assertThrows<IllegalStateException>("expected: < FUNCTION_CALL: com.anthonycr.mockingbird.sample.InterfaceToVerify1.performAction1> but was: < FUNCTION_CALL: com.anthonycr.mockingbird.sample.InterfaceToVerify1.performAction2>") {
             val classToTest = createClassToTest()
 
             classToTest.act2()
@@ -206,7 +206,7 @@ class ClassToTestTest {
 
     @Test
     fun `verification of inequitable type expected failure`() {
-        assertThrows<IllegalStateException>("Expected argument java.lang.Exception: test, found java.lang.Exception: test instead.") {
+        assertThrows<IllegalStateException>("expected: < ARGUMENT 0: java.lang.Exception: test> but was: < ARGUMENT 0: java.lang.Exception: test>") {
             val classToTest = createClassToTest()
 
             classToTest.act5()
@@ -230,7 +230,7 @@ class ClassToTestTest {
 
     @Test
     fun `verification of inequitable type with parameter verification expected failure`() {
-        assertThrows<IllegalStateException>("Expected argument java.lang.Exception: test1, found java.lang.Exception: test instead.") {
+        assertThrows<IllegalStateException>("expected: < ARGUMENT 0: java.lang.Exception: test1> but was: < ARGUMENT 0: java.lang.Exception: test>") {
             val classToTest = createClassToTest()
 
             classToTest.act5()


### PR DESCRIPTION
Updates the error message for parameter verification and function verification so that Intellij will show the "click to show difference" button when running tests.

Results in the test output in intellij showing:
```
Expected : ARGUMENT 0: tests
Actual   : ARGUMENT 0: test
<Click to see difference>
```

Closes #170 