### PR TITLE
Auto-add core dependency when applying the Gradle plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,14 +34,6 @@ plugins {
 }
 ```
 
-Then add the build dependencies to the `dependencies` block.
-
-```kotlin
-dependencies {
-    testImplementation("com.anthonycr.mockingbird:core:<latest_version>")
-}
-```
-
 Within your test, add the following annotation to a property that you wish to verify. Note that the
 property you are verifying must be an interface or abstract class with a zero argument constructor.
 All functions you wish to verify must return `Unit` and when verifying an abstract class, the

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,4 +1,5 @@
 plugins {
     alias(libs.plugins.jetbrainsKotlinJvm) apply false
     alias(libs.plugins.jetbrainsKotlinMultiplatform) apply false
+    alias(libs.plugins.buildconfig) apply false
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -16,6 +16,7 @@ compiletesting = { group = "dev.zacsweers.kctfork", name = "ksp", version = "0.1
 mockk = { group = "io.mockk", name = "mockk", version = "1.14.7" }
 coroutines-test = { group = "org.jetbrains.kotlinx", name = "kotlinx-coroutines-test", version = "1.10.2" }
 kotlin-reflect = { group = "org.jetbrains.kotlin", name = "kotlin-reflect", version.ref = "jetbrainsKotlin" }
+kotlin-gradle = { group = "org.jetbrains.kotlin", name = "kotlin-gradle-plugin", version.ref = "jetbrainsKotlin" }
 
 [plugins]
 ksp-plugin = { id = "com.google.devtools.ksp", version.ref = "ksp" }
@@ -23,3 +24,4 @@ gradle-publish = { id = "com.gradle.plugin-publish", version = "2.0.0" }
 jetbrainsKotlinJvm = { id = "org.jetbrains.kotlin.jvm", version.ref = "jetbrainsKotlin" }
 jetbrainsKotlinMultiplatform = { id = "org.jetbrains.kotlin.multiplatform", version.ref = "jetbrainsKotlin" }
 mavenPublish = { id = "com.vanniktech.maven.publish", version = "0.35.0" }
+buildconfig = { id = "com.github.gmazzo.buildconfig", version = "6.0.7" }

--- a/mockingbird-plugin/plugin/build.gradle.kts
+++ b/mockingbird-plugin/plugin/build.gradle.kts
@@ -4,6 +4,15 @@ plugins {
     id("java-gradle-plugin")
     alias(libs.plugins.gradle.publish)
     alias(libs.plugins.jetbrainsKotlinJvm)
+    alias(libs.plugins.buildconfig)
+}
+
+buildConfig {
+    useKotlinOutput {
+        internalVisibility = true
+    }
+
+    buildConfigField("String", "mockingbirdVersion", "\"${property("VERSION").toString()}\"")
 }
 
 kotlin {
@@ -14,7 +23,7 @@ kotlin {
 }
 
 dependencies {
-    implementation(kotlin("gradle-plugin-api"))
+    compileOnly(libs.kotlin.gradle)
     implementation(gradleApi())
 
     testImplementation(libs.compiletesting)

--- a/mockingbird-plugin/plugin/src/main/java/com/anthonycr/mockingbird/plugin/MockingbirdPlugin.kt
+++ b/mockingbird-plugin/plugin/src/main/java/com/anthonycr/mockingbird/plugin/MockingbirdPlugin.kt
@@ -1,12 +1,49 @@
 package com.anthonycr.mockingbird.plugin
 
+import com.anthonycr.plugins.mockingbird.plugin.BuildConfig
+import org.gradle.api.Project
 import org.gradle.api.provider.Provider
+import org.jetbrains.kotlin.gradle.dsl.KotlinBaseExtension
+import org.jetbrains.kotlin.gradle.plugin.KotlinBaseApiPlugin
 import org.jetbrains.kotlin.gradle.plugin.KotlinCompilation
 import org.jetbrains.kotlin.gradle.plugin.KotlinCompilerPluginSupportPlugin
+import org.jetbrains.kotlin.gradle.plugin.KotlinSourceSet.Companion.COMMON_TEST_SOURCE_SET_NAME
 import org.jetbrains.kotlin.gradle.plugin.SubpluginArtifact
 import org.jetbrains.kotlin.gradle.plugin.SubpluginOption
 
 class MockingbirdPlugin : KotlinCompilerPluginSupportPlugin {
+
+    override fun apply(target: Project) = with(target) {
+        pluginManager.withPlugin("org.jetbrains.kotlin.multiplatform") {
+            extensions.getByType(KotlinBaseExtension::class.java).apply {
+                sourceSets.getByName(COMMON_TEST_SOURCE_SET_NAME).dependencies {
+                    implementation("com.anthonycr.mockingbird:core:${BuildConfig.mockingbirdVersion}")
+                }
+            }
+        }
+
+        pluginManager.withPlugin("org.jetbrains.kotlin.jvm") {
+            dependencies.add("testImplementation", "com.anthonycr.mockingbird:core:${BuildConfig.mockingbirdVersion}")
+        }
+
+        pluginManager.withPlugin("org.jetbrains.kotlin.android") {
+            dependencies.apply {
+                add("testImplementation", "com.anthonycr.mockingbird:core:${BuildConfig.mockingbirdVersion}")
+                add("androidTestImplementation", "com.anthonycr.mockingbird:core:${BuildConfig.mockingbirdVersion}")
+            }
+        }
+
+        // AGP's built-in Kotlin
+        target.pluginManager.withPlugin("com.android.base") {
+            if (target.plugins.hasPlugin(KotlinBaseApiPlugin::class.java)) {
+                target.dependencies.apply {
+                    add("testImplementation", "com.anthonycr.mockingbird:core:${BuildConfig.mockingbirdVersion}")
+                    add("androidTestImplementation", "com.anthonycr.mockingbird:core:${BuildConfig.mockingbirdVersion}")
+                }
+            }
+        }
+    }
+
     override fun applyToCompilation(kotlinCompilation: KotlinCompilation<*>): Provider<List<SubpluginOption>> {
         return kotlinCompilation.target.project.provider {
             emptyList()
@@ -16,9 +53,7 @@ class MockingbirdPlugin : KotlinCompilerPluginSupportPlugin {
     override fun getCompilerPluginId(): String = "com.anthonycr.mockingbird.plugin"
 
     override fun getPluginArtifact(): SubpluginArtifact = SubpluginArtifact(
-        groupId = "com.anthonycr.mockingbird",
-        artifactId = "compiler-plugin",
-        version = "3.0.1"
+        groupId = "com.anthonycr.mockingbird", artifactId = "compiler-plugin", version = BuildConfig.mockingbirdVersion
     )
 
     override fun isApplicable(kotlinCompilation: KotlinCompilation<*>): Boolean = true


### PR DESCRIPTION
Stealing a lot of this from Burst https://github.com/cashapp/burst

The idea is that we can auto-add the core artifact as part of applying the Gradle plugin so users just need to apply the plugin