### PR TITLE
Don't restrict usage only to compilations named test

### DIFF
--- a/mockingbird-plugin/plugin/src/main/java/com/anthonycr/mockingbird/plugin/MockingbirdPlugin.kt
+++ b/mockingbird-plugin/plugin/src/main/java/com/anthonycr/mockingbird/plugin/MockingbirdPlugin.kt
@@ -21,6 +21,5 @@ class MockingbirdPlugin : KotlinCompilerPluginSupportPlugin {
         version = "3.0.0"
     )
 
-    override fun isApplicable(kotlinCompilation: KotlinCompilation<*>): Boolean =
-        kotlinCompilation.name == "test"
+    override fun isApplicable(kotlinCompilation: KotlinCompilation<*>): Boolean = true
 }


### PR DESCRIPTION
Android projects have compilations that have other names like `testDebug` and `testRelease`. We don't need to restrict compilation only to test sources, as there could be valid reasons to target other compilations.